### PR TITLE
Enable VoldemortBuildandPush job type in azkaban-rb

### DIFF
--- a/lib/azkaban-rb/tasks.rb
+++ b/lib/azkaban-rb/tasks.rb
@@ -286,6 +286,13 @@ module Azkaban
     end
   end
 
+  class VoldemortBuildAndPushJob < JobFile    
+    def initialize(task, ext)
+      super(task,ext)
+      set "type"=>"VoldemortBuildAndPush"
+    end
+  end
+
   class JavaProcessJob < JobFile    
     def initialize(task, ext)
       super(task,ext)

--- a/lib/azkaban-rb/tasks.rb
+++ b/lib/azkaban-rb/tasks.rb
@@ -289,7 +289,7 @@ module Azkaban
   class VoldemortBuildAndPushJob < JobFile    
     def initialize(task, ext)
       super(task,ext)
-      set "type"=>"VoldemortBuildAndPush"
+      set "type"=>"VoldemortBuildandPush"
     end
   end
 

--- a/lib/azkaban-rb/tasks.rb
+++ b/lib/azkaban-rb/tasks.rb
@@ -348,6 +348,10 @@ def command_job(*args,&b)
   make_job(Azkaban::CommandJob, args, b)
 end
 
+def voldemort_build_and_push(*args,&b)
+  make_job(Azkaban::VoldemortBuildAndPushJob, args, b)
+end
+
 def make_job(job_class,args,b)
   job = job_class.new(task(*args) { job.write }, ".job")
   unless b.nil?    


### PR DESCRIPTION
Supporting VoldemortBuildandPush jobs in azkaban-rb to conform with the new VoldemortBuildandPush job type available on Azkaban.  
